### PR TITLE
Fix thread worker count

### DIFF
--- a/download.py
+++ b/download.py
@@ -96,7 +96,8 @@ def download_files(
     embeddings_column: str = "emb",
     quantize: bool = False,
 ):
-    workers = multiprocessing.cpu_count() - 2
+    # Leave at least one thread free to keep the system responsive
+    workers = max(1, multiprocessing.cpu_count() - 2)
     with ThreadPoolExecutor(max_workers=workers) as executor:
         future_to_url = {
             executor.submit(


### PR DESCRIPTION
## Summary
- prevent creating a zero or negative worker pool in `download_files`

## Testing
- `python -m py_compile download.py kernels.py`