### PR TITLE
Fix README typo and update script docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ float jaccard(std::uint8_t const* a_vector, std::uint8_t const* b_vector, std::s
     for (std::size_t i = 0; i < count_octets; ++i) {
         std::uint8_t a_octet = a_vector[i], b_octet = b_vector[i];
         intersection += std::popcount(a_octet & b_octet);
-        union_ += std::popcount(rst_octet | b_octet);
+        union_ += std::popcount(a_octet | b_octet);
     }
     return (float)intersection / (float)union_;
 }

--- a/download.py
+++ b/download.py
@@ -7,13 +7,13 @@
 # ]
 # ///
 
-# ? This script downloads and processes precompute vector embeddings
+# ? This script downloads and processes precomputed vector embeddings
 # ? of WikiPedia from Hugging Face. To use it:
 # ?
 # ?     uv run --script download.py --dataset cohere-en
 # ?     uv run --script download.py --dataset cohere-en --quantize
 # ?
-# ? Consider checking the `harley-seal.py` script afterwards with tests
+# ? Consider checking the `kernels.py` script afterwards with tests
 # ? for advanced population-counting schemes and other optimizations.
 
 import math


### PR DESCRIPTION
## Summary
- correct variable name in README example
- update download.py header comment to reference precomputed vectors and correct script name

## Testing
- `python -m py_compile download.py`
- `python -m py_compile indexing.py kernels.py`
